### PR TITLE
dts: Include devicetree.h instead of generated_dts_board.h

### DIFF
--- a/boot/zephyr/include/sysflash/sysflash.h
+++ b/boot/zephyr/include/sysflash/sysflash.h
@@ -3,7 +3,7 @@
 #ifndef __SYSFLASH_H__
 #define __SYSFLASH_H__
 
-#include <generated_dts_board.h>
+#include <devicetree.h>
 #include <mcuboot_config/mcuboot_config.h>
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -10,7 +10,7 @@
 #include <nrf_cc310_bl_init.h>
 #include <nrf_cc310_bl_hash_sha256.h>
 #include <nrf_cc310_bl_ecdsa_verify_secp256r1.h>
-#include <generated_dts_board.h>
+#include <devicetree.h>
 #include <string.h>
 
 typedef nrf_cc310_bl_hash_context_sha256_t bootutil_sha256_context;

--- a/scripts/assemble.py
+++ b/scripts/assemble.py
@@ -50,7 +50,7 @@ class Assembly():
     def find_slots(self, bootdir):
         offsets = {}
         sizes = {}
-        with open(os.path.join(bootdir, 'zephyr', 'include', 'generated', 'generated_dts_board_unfixed.h'), 'r') as fd:
+        with open(os.path.join(bootdir, 'zephyr', 'include', 'generated', 'devicetree_unfixed.h'), 'r') as fd:
             for line in fd:
                 m = offset_re.match(line)
                 if m is not None:
@@ -60,7 +60,7 @@ class Assembly():
                     sizes[m.group(1)] = int(m.group(3), 0)
 
         if not same_keys(offsets, sizes):
-            raise Exception("Inconsistent data in generated_dts_board.h")
+            raise Exception("Inconsistent data in devicetree.h")
 
         # We care about the MCUBOOT, IMAGE_0, and IMAGE_1 partitions.
         if 'MCUBOOT' not in offsets:


### PR DESCRIPTION
Needed for https://github.com/zephyrproject-rtos/zephyr/pull/20757, to
avoid a warning-turned-error.