### PR TITLE
[DNM] zephyr: arm_cleanup.c: use <.../cortex_m/cmsis.h>

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <arch/arm/aarch32/cortex_m/cmsis.h>
 
 void cleanup_arm_nvic(void) {
 	/* Allow any pending interrupts to be recognized */


### PR DESCRIPTION
<b>Just for kick the CI</b>

Use <arch/arm/aarch32/cortex_m/cmsis.h> include instead of <zephyr.h> to
get access to Cortex-M CMSIS API. zephyr.h provides kernel API, does not
guarantee access to CPU internals.

Fixes: #699 "Building MCUBoot for Zephyr fails on multiple ARM boards"

Signed-off-by: Piotr Mienkowski <piotr.mienkowski@gmail.com>