### PR TITLE
Convert from Zephyr to C99 types

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -485,7 +485,7 @@ boot_serial_output(void)
     bs_hdr->nh_group = htons(bs_hdr->nh_group);
 
 #ifdef __ZEPHYR__
-    crc =  crc16((u8_t *)bs_hdr, sizeof(*bs_hdr), CRC_CITT_POLYMINAL,
+    crc =  crc16((uint8_t *)bs_hdr, sizeof(*bs_hdr), CRC_CITT_POLYMINAL,
                  CRC16_INITIAL_CRC, false);
     crc =  crc16(data, len, CRC_CITT_POLYMINAL, crc, true);
 #else

--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -12,11 +12,11 @@ void cleanup_arm_nvic(void) {
 	__disable_irq();
 
 	/* Disable NVIC interrupts */
-	for (u8_t i = 0; i < ARRAY_SIZE(NVIC->ICER); i++) {
+	for (uint8_t i = 0; i < ARRAY_SIZE(NVIC->ICER); i++) {
 		NVIC->ICER[i] = 0xFFFFFFFF;
 	}
 	/* Clear pending NVIC interrupts */
-	for (u8_t i = 0; i < ARRAY_SIZE(NVIC->ICPR); i++) {
+	for (uint8_t i = 0; i < ARRAY_SIZE(NVIC->ICPR); i++) {
 		NVIC->ICPR[i] = 0xFFFFFFFF;
 	}
 }

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -79,7 +79,7 @@ K_SEM_DEFINE(boot_log_sem, 1, 1);
 static inline bool boot_skip_serial_recovery()
 {
 #if NRF_POWER_HAS_RESETREAS
-    u32_t rr = nrf_power_resetreas_get(NRF_POWER);
+    uint32_t rr = nrf_power_resetreas_get(NRF_POWER);
 
     return !(rr == 0 || (rr & NRF_POWER_RESETREAS_RESETPIN_MASK));
 #else
@@ -295,7 +295,7 @@ void main(void)
 #ifdef CONFIG_MCUBOOT_SERIAL
 
     struct device *detect_port;
-    u32_t detect_value = !CONFIG_BOOT_SERIAL_DETECT_PIN_VAL;
+    uint32_t detect_value = !CONFIG_BOOT_SERIAL_DETECT_PIN_VAL;
 
     detect_port = device_get_binding(CONFIG_BOOT_SERIAL_DETECT_PORT);
     __ASSERT(detect_port, "Error: Bad port for boot serial detection.\n");

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -47,7 +47,7 @@ static struct line_input line_bufs[2];
 static sys_slist_t avail_queue;
 static sys_slist_t lines_queue;
 
-static u16_t cur;
+static uint16_t cur;
 
 static int boot_uart_fifo_getline(char **line);
 static int boot_uart_fifo_init(void);
@@ -118,7 +118,7 @@ static void
 boot_uart_fifo_callback(struct device *dev)
 {
 	static struct line_input *cmd;
-	u8_t byte;
+	uint8_t byte;
 	int rx;
 
 	uart_irq_update(uart_dev);
@@ -203,7 +203,7 @@ boot_uart_fifo_init(void)
 		}
 	}
 #endif
-	u8_t c;
+	uint8_t c;
 
 	if (!uart_dev) {
 		return (-1);


### PR DESCRIPTION
Convert to use C99 types as we intend to deprecate the zephyr
specific integer types.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>