### PR TITLE
zephyr: Fix serial recovery compilation warnings

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -317,7 +317,7 @@ void main(void)
 
 #ifdef CONFIG_MCUBOOT_SERIAL
 
-    struct device *detect_port;
+    struct device const *detect_port;
     uint32_t detect_value = !CONFIG_BOOT_SERIAL_DETECT_PIN_VAL;
 
     detect_port = device_get_binding(CONFIG_BOOT_SERIAL_DETECT_PORT);

--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -41,7 +41,7 @@ struct line_input {
 	char line[CONFIG_BOOT_MAX_LINE_INPUT_LEN];
 };
 
-static struct device *uart_dev;
+static struct device const *uart_dev;
 static struct line_input line_bufs[2];
 
 static sys_slist_t avail_queue;
@@ -115,7 +115,7 @@ boot_console_init(void)
 }
 
 static void
-boot_uart_fifo_callback(struct device *dev, void *user_data)
+boot_uart_fifo_callback(const struct device *dev, void *user_data)
 {
 	static struct line_input *cmd;
 	uint8_t byte;


### PR DESCRIPTION
**This is port of commit that was reviewed here: https://github.com/JuulLabs-OSS/mcuboot/pull/797**

Missing const on pointers to device structures caused compilation
warnings when compiling bootloader with serial recovery enabled.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

West update PR here: https://github.com/zephyrproject-rtos/zephyr/pull/28310