### PR TITLE
boot: zephyr: add nrfx watchdog kick during boot region copy

### DIFF
--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -138,9 +138,38 @@
 
 #endif /* !__BOOTSIM__ */
 
+#if CONFIG_NRFX_WDT
+#include <nrfx_wdt.h>
+
+#define FEED_WDT_INST(id)                                    \
+    do {                                                     \
+        nrfx_wdt_t wdt_inst_##id = NRFX_WDT_INSTANCE(id);    \
+        for (uint8_t i = 0; i < NRF_WDT_CHANNEL_NUMBER; i++) \
+        {                                                    \
+            nrf_wdt_reload_request_set(wdt_inst_##id.p_reg,  \
+                (nrf_wdt_rr_register_t)(NRF_WDT_RR0 + i));   \
+        }                                                    \
+    } while (0)
+#if defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1)
+#define MCUBOOT_WATCHDOG_FEED() \
+    do {                        \
+        FEED_WDT_INST(0);       \
+        FEED_WDT_INST(1);       \
+    } while (0)
+#elif defined(CONFIG_NRFX_WDT0)
+#define MCUBOOT_WATCHDOG_FEED() \
+    FEED_WDT_INST(0);
+#else /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
+#error "No NRFX WDT instances enabled"
+#endif /* defined(CONFIG_NRFX_WDT0) && defined(CONFIG_NRFX_WDT1) */
+
+#else /* CONFIG_NRFX_WDT */
+
 #define MCUBOOT_WATCHDOG_FEED()         \
     do {                                \
         /* TODO: to be implemented */   \
     } while (0)
+
+#endif /* CONFIG_NRFX_WDT */
 
 #endif /* __MCUBOOT_CONFIG_H__ */


### PR DESCRIPTION
This fixes soft-bricks that we have seen as a result
of the bootloader being interrupted by the watchdog
when running the nrf series chips.

Signed-off-by: Emil Hammarstrom <emil.hammarstrom@assaabloy.com>