### PR TITLE
zephyr: Fix for issue with path length on windows

### DIFF
--- a/boot/bootutil/zephyr/CMakeLists.txt
+++ b/boot/bootutil/zephyr/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(MCUBOOT_BOOTUTIL INTERFACE
   ../../zephyr/include
 )
 
-zephyr_library()
+zephyr_library_named(mcuboot_util)
 zephyr_library_sources(
   ../src/bootutil_public.c
     )


### PR DESCRIPTION
Switch to use zephyr_library_named() which creates a shorter library name.

Signed-off-by: Mariusz Poslinski <mariusz.poslinski@nordicsemi.no>