### PR TITLE
zephyr: CDC ACM UART node to specific overlays

### DIFF
--- a/boot/zephyr/boards/nrf52840_big.overlay
+++ b/boot/zephyr/boards/nrf52840_big.overlay
@@ -28,3 +28,10 @@
 			};
 	};
 };
+
+&zephyr_udc0 {
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "CDC_ACM_0";
+	};
+};

--- a/boot/zephyr/dts.overlay
+++ b/boot/zephyr/dts.overlay
@@ -3,10 +3,3 @@
 		zephyr,code-partition = &boot_partition;
 	};
 };
-
-&zephyr_udc0 {
-	cdc_acm_uart0 {
-		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
-	};
-};

--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -17,6 +17,7 @@ tests:
   sample.bootloader.mcuboot.usb_cdc_acm_recovery:
     tags: bootloader_mcuboot
     platform_allow:  nrf52840dongle_nrf52840
+    extra_args: DTC_OVERLAY_FILE=./usb_cdc_acm.overlay
     integration_platforms:
       - nrf52840dongle_nrf52840
   sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:

--- a/boot/zephyr/usb_cdc_acm.overlay
+++ b/boot/zephyr/usb_cdc_acm.overlay
@@ -1,0 +1,6 @@
+&zephyr_udc0 {
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		label = "CDC_ACM_0";
+	};
+};


### PR DESCRIPTION
Move CDC ACM UART node from common DTC overlay to
specific overlays, nrf52840_big.overlays and usb_cdc_acm.overlays.

See comment https://github.com/zephyrproject-rtos/zephyr/pull/37085#pullrequestreview-735078765