### PR TITLE
boot: zephyr: Config mimxrt1020_evk and mimxrt1050_evk_qspi

### DIFF
--- a/boot/zephyr/boards/mimxrt1020_evk.conf
+++ b/boot/zephyr/boards/mimxrt1020_evk.conf
@@ -1,0 +1,4 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024

--- a/boot/zephyr/boards/mimxrt1050_evk_qspi.conf
+++ b/boot/zephyr/boards/mimxrt1050_evk_qspi.conf
@@ -1,0 +1,4 @@
+# Copyright 2021 NXP
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_BOOT_MAX_IMG_SECTORS=1024


### PR DESCRIPTION
The mimxrt1020_evk and mimxrt1050_evk_qspi boards have large
slots so we need to increase CONFIG_BOOT_MAX_IMG_SECTORS from
the default.

Signed-off-by: Xabier Marquiegui <xmarquiegui@ainguraiiot.com>