### PR TITLE
bugfixes for zephyr-rtos 3.0.0-rc2

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -555,9 +555,8 @@ boot_serial_output(void)
     bs_hdr->nh_group = htons(bs_hdr->nh_group);
 
 #ifdef __ZEPHYR__
-    crc =  crc16((uint8_t *)bs_hdr, sizeof(*bs_hdr), CRC_CITT_POLYMINAL,
-                 CRC16_INITIAL_CRC, false);
-    crc =  crc16(data, len, CRC_CITT_POLYMINAL, crc, true);
+    crc =  crc16_itu_t(CRC16_INITIAL_CRC, (uint8_t *)bs_hdr, sizeof(*bs_hdr));
+    crc =  crc16_itu_t(crc, data, len);
 #else
     crc = crc16_ccitt(CRC16_INITIAL_CRC, bs_hdr, sizeof(*bs_hdr));
     crc = crc16_ccitt(crc, data, len);
@@ -631,7 +630,7 @@ boot_serial_in_dec(char *in, int inlen, char *out, int *out_off, int maxout)
 
     out += sizeof(uint16_t);
 #ifdef __ZEPHYR__
-    crc = crc16(out, len, CRC_CITT_POLYMINAL, CRC16_INITIAL_CRC, true);
+    crc = crc16_itu_t(CRC16_INITIAL_CRC, out, len);
 #else
     crc = crc16_ccitt(CRC16_INITIAL_CRC, out, len);
 #endif

--- a/boot/zephyr/boot_serial_extensions.c
+++ b/boot/zephyr/boot_serial_extensions.c
@@ -19,7 +19,7 @@
 #include "bootutil/bootutil_public.h"
 #include "bootutil/boot_hooks.h"
 
-MCUBOOT_LOG_MODULE_DECLARE(mcuboot);
+BOOT_LOG_MODULE_DECLARE(mcuboot);
 
 #ifdef CONFIG_BOOT_MGMT_CUSTOM_STORAGE_ERASE
 static int bs_custom_storage_erase(cbor_state_t *cs)
@@ -31,11 +31,11 @@ static int bs_custom_storage_erase(cbor_state_t *cs)
     rc = flash_area_open(FLASH_AREA_ID(storage), &fa);
 
     if (rc < 0) {
-        LOG_ERR("failed to open flash area");
+        BOOT_LOG_ERR("failed to open flash area");
     } else {
         rc = flash_area_erase(fa, 0, FLASH_AREA_SIZE(storage));
         if (rc < 0) {
-            LOG_ERR("failed to erase flash area");
+            BOOT_LOG_ERR("failed to erase flash area");
         }
         flash_area_close(fa);
     }


### PR DESCRIPTION
cherry-picked following patches:

- boot_serial: Adapt to Zephyr's new CRC APIs
- zephyr/boot_serial_extension: us BOOT_LOG instead of LOG_