### PR TITLE
boot: zephyr: add Kconfig for arm cortex-m that implements a cache

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -196,7 +196,7 @@ static void do_boot(struct boot_rsp *rsp)
 #if CONFIG_MCUBOOT_CLEANUP_ARM_CORE
     cleanup_arm_nvic(); /* cleanup NVIC registers */
 
-#ifdef CONFIG_CPU_CORTEX_M7
+#ifdef CONFIG_CPU_CORTEX_M_HAS_CACHE
     /* Disable instruction cache and data cache before chain-load the application */
     SCB_DisableDCache();
     SCB_DisableICache();


### PR DESCRIPTION
The Cache is an optional configuration of both the ARM Cortex-M7 and
Cortex-M55. Previously, it was just checking that it was just an M7
rather than knowing that the CPU actually was built with the cache.

This just follows the pull request into zephyr https://github.com/zephyrproject-rtos/zephyr/pull/44815

Signed-off-by: Ryan McClelland ryanmcclelland@fb.com