### PR TITLE
cherry-pick fix for zephyr 3.1.0-rc3

### DIFF
--- a/boot/espressif/include/esp_loader.h
+++ b/boot/espressif/include/esp_loader.h
@@ -6,4 +6,9 @@
 
 #pragma once
 
+void start_cpu0_image(int image_index, int slot, unsigned int hdr_offset);
+#ifdef CONFIG_ESP_MULTI_PROCESSOR_BOOT
+void start_cpu1_image(int image_index, int slot, unsigned int hdr_offset);
+#endif
+
 void esp_app_image_load(int image_index, int slot, unsigned int hdr_offset, unsigned int *entry_addr);

--- a/boot/espressif/port/esp32/ld/bootloader.ld
+++ b/boot/espressif/port/esp32/ld/bootloader.ld
@@ -55,6 +55,7 @@ SECTIONS
     *libhal.a:esp_efuse_api.*(.literal .text .literal.* .text.*)
     *libhal.a:esp_efuse_utility.*(.literal .text .literal.* .text.*)
     *libhal.a:esp_efuse_api_key_esp32.*(.literal .text .literal.* .text.*)
+    *libhal.a:app_cpu_start.*(.literal .text .literal.* .text.*)
     *esp_mcuboot.*(.literal .text .literal.* .text.*)
     *esp_loader.*(.literal .text .literal.* .text.*)
     *(.fini.literal)


### PR DESCRIPTION
Fix which was omitted in previous update #78.

espressif:esp32: Move app entry point call back to iram_loader_seg region