### PR TITLE
boot: zephyr: fix build with CONFIG_LOG_MODE_MINIMAL=n

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -332,7 +332,7 @@ void boot_log_thread_func(void *dummy1, void *dummy2, void *dummy3)
      log_init();
 
      while (1) {
-             if (log_process(false) == false) {
+             if (log_process() == false) {
                     if (boot_log_stop) {
                         break;
                     }


### PR DESCRIPTION
With minimal logging boot_log_thread_func() is never compiled, masking
the apparent API change that occurred over time. The boolean argument is
no longer present in Zephyr.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@huawei.com>