### PR TITLE
include: add "zephyr/" include prefix

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -28,12 +28,12 @@
 #include "zcbor_encode.h"
 
 #ifdef __ZEPHYR__
-#include <sys/reboot.h>
-#include <sys/byteorder.h>
-#include <sys/__assert.h>
-#include <drivers/flash.h>
-#include <sys/crc.h>
-#include <sys/base64.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/sys/base64.h>
 #else
 #include <bsp/bsp.h>
 #include <hal/hal_system.h>


### PR DESCRIPTION
Add relevant "zephyr/" prefixes to allow building with LEGACY_INCLUDE_PATH=n.