### PR TITLE
zephyr: remove flash_device_get_binding

### DIFF
--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -21,22 +21,16 @@ BOOT_LOG_MODULE_DECLARE(mcuboot);
 #if (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
 #define FLASH_DEVICE_ID SOC_FLASH_0_ID
 #define FLASH_DEVICE_BASE CONFIG_FLASH_BASE_ADDRESS
-#elif (defined(CONFIG_XTENSA) && defined(DT_JEDEC_SPI_NOR_0_LABEL))
+#define FLASH_DEVICE_NODE DT_CHOSEN(zephyr_flash_controller)
+#elif (defined(CONFIG_XTENSA) && DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor))
 #define FLASH_DEVICE_ID SPI_FLASH_0_ID
 #define FLASH_DEVICE_BASE 0
+#define FLASH_DEVICE_NODE DT_INST(0, jedec_spi_nor)
 #else
 #error "FLASH_DEVICE_ID could not be determined"
 #endif
 
-static const struct device *flash_dev;
-
-const struct device *flash_device_get_binding(char *dev_name)
-{
-    if (!flash_dev) {
-        flash_dev = device_get_binding(dev_name);
-    }
-    return flash_dev;
-}
+static const struct device *flash_dev = DEVICE_DT_GET(FLASH_DEVICE_NODE);
 
 int flash_device_base(uint8_t fd_id, uintptr_t *ret)
 {

--- a/boot/zephyr/include/flash_map_backend/flash_map_backend.h
+++ b/boot/zephyr/include/flash_map_backend/flash_map_backend.h
@@ -34,12 +34,6 @@ extern "C" {
 #include <inttypes.h>
 #include <sys/types.h>
 
-/* Retrieve the flash device with the given name.
- *
- * Returns the flash device on success, or NULL on failure.
- */
-const struct device *flash_device_get_binding(char *dev_name);
-
 /*
  * Retrieve a memory-mapped flash device's base address.
  *

--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -27,15 +27,11 @@
 
 #endif /* !defined(MCUBOOT_TARGET_CONFIG) */
 
-#if DT_NODE_HAS_PROP(DT_INST(0, jedec_spi_nor), label)
-#define JEDEC_SPI_NOR_0_LABEL DT_LABEL(DT_INST(0, jedec_spi_nor))
-#endif
-
 /*
  * Sanity check the target support.
  */
 #if (!defined(CONFIG_XTENSA) && !DT_HAS_CHOSEN(zephyr_flash_controller)) || \
-    (defined(CONFIG_XTENSA) && !defined(JEDEC_SPI_NOR_0_LABEL)) || \
+    (defined(CONFIG_XTENSA) && !DT_NODE_EXISTS(DT_INST(0, jedec_spi_nor))) || \
     !defined(FLASH_ALIGN) ||                  \
     !(FLASH_AREA_LABEL_EXISTS(image_0)) || \
     !(FLASH_AREA_LABEL_EXISTS(image_1) || CONFIG_SINGLE_APPLICATION_SLOT) || \

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -506,21 +506,6 @@ void main(void)
 
     mcuboot_status_change(MCUBOOT_STATUS_STARTUP);
 
-#if (!defined(CONFIG_XTENSA) && DT_HAS_CHOSEN(zephyr_flash_controller))
-    if (!flash_device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_flash_controller)))) {
-        BOOT_LOG_ERR("Flash device %s not found",
-		     DT_LABEL(DT_CHOSEN(zephyr_flash_controller)));
-        while (1)
-            ;
-    }
-#elif (defined(CONFIG_XTENSA) && defined(JEDEC_SPI_NOR_0_LABEL))
-    if (!flash_device_get_binding(JEDEC_SPI_NOR_0_LABEL)) {
-        BOOT_LOG_ERR("Flash device %s not found", JEDEC_SPI_NOR_0_LABEL);
-        while (1)
-            ;
-    }
-#endif
-
 #ifdef CONFIG_MCUBOOT_SERIAL
     if (detect_pin() &&
             !boot_skip_serial_recovery()) {


### PR DESCRIPTION
remove flash_device_get_binding as we can utilizes DEVICE_DT_GET to
get the flash_dev pointer set at build time.  This removes usage of
device_get_binding and handles the lack of 'label' properties in
the devicetree better.

Signed-off-by: Kumar Gala <galak@kernel.org>


Merge using **Merge by Create a Merge commit!**