### PR TITLE
Synch to mcu-tools/mcuboot of 20.12.2022

### DIFF
--- a/boot/espressif/hal/include/mcuboot_config/mcuboot_config.h
+++ b/boot/espressif/hal/include/mcuboot_config/mcuboot_config.h
@@ -84,6 +84,18 @@
  */
 #define MCUBOOT_VALIDATE_PRIMARY_SLOT
 
+#ifdef CONFIG_ESP_DOWNGRADE_PREVENTION
+#define MCUBOOT_DOWNGRADE_PREVENTION 1
+/* MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER is used later as bool value so it is
+ * always defined, (unlike MCUBOOT_DOWNGRADE_PREVENTION which is only used in
+ * preprocessor condition and my be not defined) */
+#  ifdef CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER
+#    define MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER 1
+#  else
+#    define MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER 0
+#  endif
+#endif
+
 /*
  * Flash abstraction
  */

--- a/boot/espressif/port/esp32/bootloader.conf
+++ b/boot/espressif/port/esp32/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32c3/bootloader.conf
+++ b/boot/espressif/port/esp32c3/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32s2/bootloader.conf
+++ b/boot/espressif/port/esp32s2/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32s3/bootloader.conf
+++ b/boot/espressif/port/esp32s3/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables multi image, if it is not defined, it is assumed
 # only one updatable image
 # CONFIG_ESP_IMAGE_NUMBER=2

--- a/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
+++ b/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
@@ -7,7 +7,6 @@
 /delete-node/ &boot_partition;
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 	partitions {

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ set -e
 pushd .. &&\
    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
    pushd trusted-firmware-m &&\
-   git checkout TF-Mv1.4.0 &&\
+   git checkout TF-Mv1.7.0 &&\
    popd
 
 if [[ $GITHUB_ACTIONS == true ]]; then

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ cmake -B $TFM_BUILD_DIR \
 cd $TFM_BUILD_DIR
 make -j install
 
-BOOTLOADER_AXF='./install/outputs/ARM/MPS2/AN521/bl2.axf'
+BOOTLOADER_AXF='./install/outputs/bl2.axf'
 
 $MCUBOOT_PATH/ci/fih_test_docker/run_fi_test.sh $BOOTLOADER_AXF $SKIP_SIZE $DAMAGE_TYPE> fih_test_output.yaml
 

--- a/ci/fih_test_docker/fi_tester_gdb.sh
+++ b/ci/fih_test_docker/fi_tester_gdb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ function skip_instruction {
 
     cat >commands.gdb <<EOF
 target remote localhost: 1234
+file $IMAGE_DIR/bl2.axf
+b boot_go_for_image_id if image_id == 0
+continue
+delete breakpoints 1
 b *$SKIP_ADDRESS
 continue&
 eval "shell sleep 0.5"
@@ -138,7 +142,7 @@ usage() {
 
 #defaults
 SKIP=2
-BIN_DIR=$(pwd)/install/outputs/ARM/MPS2/AN521
+BIN_DIR=$(pwd)/install/outputs
 AXF_FILE=$BIN_DIR/bl2.axf
 GDB=gdb-multiarch
 BOOTLOADER=true

--- a/docs/design.md
+++ b/docs/design.md
@@ -226,13 +226,13 @@ allows hundreds to thousands of field upgrades in production is recommended.
 swap-using scratch algorithm assumes that the primary and the secondary image
 slot areas sizes are equal.
 The maximum image size available for the application
-will be:  
+will be:
 ```
 maximum-image-size = image-slot-size - image-trailer-size
 ```
 
-Where:  
-  `image-slot-size` is the size of the image slot.  
+Where:
+  `image-slot-size` is the size of the image slot.
   `image-trailer-size` is the size of the image trailer.
 
 ### [Swap without using scratch](#image-swap-no-scratch)
@@ -241,8 +241,8 @@ This algorithm is an alternative to the swap-using-scratch algorithm.
 It uses an additional sector in the primary slot to make swap possible.
 The algorithm works as follows:
 
-  1.	Moves all sectors of the primary slot up by one sector.  
-    Beginning from N=0:  
+  1.	Moves all sectors of the primary slot up by one sector.
+    Beginning from N=0:
   2.	Copies the N-th sector from the secondary slot to the N-th sector of the
   primary slot.
   3.	Copies the (N+1)-th sector from the primary slot to the N-th sector of the
@@ -257,13 +257,13 @@ The algorithm is limited to support sectors of the same
 sector layout. All slot's sectors should be of the same size.
 
 When using this algorithm the maximum image size available for the application
-will be:  
+will be:
 ```
 maximum-image-size = (N-1) * slot-sector-size - image-trailer-sectors-size
 ```
 
-Where:  
-  `N` is the number of sectors in the primary slot.  
+Where:
+  `N` is the number of sectors in the primary slot.
   `image-trailer-sectors-size` is the size of the image trailer rounded up to
   the total size of sectors its occupied. For instance if the image-trailer-size
   is equal to 1056 B and the sector size is equal to 1024 B, then
@@ -1468,8 +1468,8 @@ are issued from the MCUboot source directory):
 ```sh
 $ mkdir docker
 $ ./ci/fih-tests_install.sh
-$ FIH_LEVEL=MCUBOOT_FIH_PROFILE_MEDIUM BUILD_TYPE=RELEASE SKIP_SIZE=2 \
-    DAMAGE_TYPE=SIGNATURE ./ci/fih-tests_run.sh
+$ FIH_LEVEL=MEDIUM BUILD_TYPE=RELEASE SKIP_SIZE=2 DAMAGE_TYPE=SIGNATURE \
+     ./ci/fih-tests_run.sh
 ```
 On the travis CI the environment variables in the last command are set based on
 the configs provided in the `.travis.yaml`

--- a/docs/readme-espressif.md
+++ b/docs/readme-espressif.md
@@ -130,6 +130,28 @@ For signing with a crypto key and guarantee the authenticity of the image being 
 esptool.py -p <PORT> -b <BAUD> --before default_reset --after hard_reset --chip <TARGET>  write_flash --flash_mode dio --flash_size <FLASH_SIZE> --flash_freq 40m <SLOT_OFFSET> <SIGNED_BIN>
 ```
 
+# [Downgrade prevention](#downgrade-prevention)
+
+Downgrade prevention (avoid updating of images to an older version) can be enabled using the following configuration:
+
+```
+CONFIG_ESP_DOWNGRADE_PREVENTION=y
+```
+
+MCUboot will then verify and compare the new image version number with the current one before perform an update swap.
+
+Version number is added to the image when signing it with `imgtool` (`-v` parameter, e.g. `-v 1.0.0`).
+
+### [Downgrade prevention with security counter](#downgrade-prevention-with-security-counter)
+
+It is also possible to rely on a security counter, also added to the image when signing with `imgtool` (`-s` parameter), apart from version number. This allows image downgrade at some extent, since any update must have greater or equal security counter value. Enable using the following configuration:
+
+```
+CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+```
+
+E.g.: if the current image was signed using `-s 1` parameter, an eventual update image must have been signed using security counter `-s 1` or greater.
+
 # [Security Chain on Espressif port](#security-chain-on-espressif-port)
 
 [MCUboot encrypted images](encrypted_images.md) do not provide full code confidentiality when only external storage is available (see [Threat model](encrypted_images.md#threat-model)) since by MCUboot design the image in Primary Slot, from where the image is executed, is stored plaintext.

--- a/ext/nrf/cc310_glue.c
+++ b/ext/nrf/cc310_glue.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include "cc310_glue.h"

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #ifndef NRF_CC310_GLUE_H__
 #define NRF_CC310_GLUE_H__


### PR DESCRIPTION
Synchronized to:
https://github.com/mcu-tools/mcuboot/commit/d165e9b2a52bcf01164d7e2529156a91a7a92d83

ci: fih: update TF-M version to 1.7.0 and adjust test suite
docs: fix FIH example command in design.md
boot: Update Nordic's license identifier tag
espressif: add downgrade prevention feature
boot: zephyr: boards: nrf52840dk: Fix overlay
