### PR TITLE
boot: zephyr: Only call sys_clock_disable when supported

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -190,7 +190,9 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
 #endif
 
-    sys_clock_disable();
+    if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {
+        sys_clock_disable();
+    }
 
 #ifdef CONFIG_USB_DEVICE_STACK
     /* Disable the USB to prevent it from firing interrupts */


### PR DESCRIPTION
Only call sys_clock_disable when the system clock driver support this feature.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>