### PR TITLE
synchronized up to the mcu-tool/mcuboot 90b8f690

### DIFF
--- a/boot/espressif/hal/include/mcuboot_config/mcuboot_config.h
+++ b/boot/espressif/hal/include/mcuboot_config/mcuboot_config.h
@@ -84,6 +84,18 @@
  */
 #define MCUBOOT_VALIDATE_PRIMARY_SLOT
 
+#ifdef CONFIG_ESP_DOWNGRADE_PREVENTION
+#define MCUBOOT_DOWNGRADE_PREVENTION 1
+/* MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER is used later as bool value so it is
+ * always defined, (unlike MCUBOOT_DOWNGRADE_PREVENTION which is only used in
+ * preprocessor condition and my be not defined) */
+#  ifdef CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER
+#    define MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER 1
+#  else
+#    define MCUBOOT_DOWNGRADE_PREVENTION_SECURITY_COUNTER 0
+#  endif
+#endif
+
 /*
  * Flash abstraction
  */

--- a/boot/espressif/port/esp32/bootloader.conf
+++ b/boot/espressif/port/esp32/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32c3/bootloader.conf
+++ b/boot/espressif/port/esp32c3/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32s2/bootloader.conf
+++ b/boot/espressif/port/esp32s2/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables the MCUboot Serial Recovery, that allows the use of
 # MCUMGR to upload a firmware through the serial port
 # CONFIG_ESP_MCUBOOT_SERIAL=y

--- a/boot/espressif/port/esp32s3/bootloader.conf
+++ b/boot/espressif/port/esp32s3/bootloader.conf
@@ -12,6 +12,12 @@ CONFIG_ESP_MCUBOOT_WDT_ENABLE=y
 CONFIG_ESP_SCRATCH_OFFSET=0x210000
 CONFIG_ESP_SCRATCH_SIZE=0x40000
 
+# When enabled, prevents updating image to an older version
+# CONFIG_ESP_DOWNGRADE_PREVENTION=y
+# This option makes downgrade prevention rely also on security
+# counter (defined using imgtool) instead of only image version
+# CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+
 # Enables multi image, if it is not defined, it is assumed
 # only one updatable image
 # CONFIG_ESP_IMAGE_NUMBER=2

--- a/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
+++ b/boot/mynewt/flash_map_backend/include/flash_map_backend/flash_map_backend.h
@@ -10,6 +10,7 @@
 #include <sysflash/sysflash.h>
 #include <flash_map/flash_map.h>
 #include <mcuboot_config/mcuboot_config.h>
+#include <unistd.h>  /* off_t */
 
 #if (MCUBOOT_IMAGE_NUMBER == 1)
 
@@ -40,6 +41,13 @@
 int flash_area_id_from_multi_image_slot(int image_index, int slot);
 int flash_area_id_to_multi_image_slot(int image_index, int area_id);
 
+struct flash_sector {
+    uint32_t fs_off;
+    uint32_t fs_size;
+};
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector);
+
 static inline uint8_t flash_area_get_id(const struct flash_area *fa)
 {
     return fa->fa_id;
@@ -58,6 +66,11 @@ static inline uint32_t flash_area_get_off(const struct flash_area *fa)
 static inline uint32_t flash_area_get_size(const struct flash_area *fa)
 {
     return fa->fa_size;
+}
+
+static inline uint32_t flash_sector_get_off(const struct flash_sector *fs)
+{
+    return fs->fs_off;
 }
 
 #endif /* __FLASH_MAP_BACKEND_H__ */

--- a/boot/mynewt/flash_map_backend/src/flash_map_extended.c
+++ b/boot/mynewt/flash_map_backend/src/flash_map_extended.c
@@ -19,6 +19,8 @@
 
 #include <flash_map/flash_map.h>
 #include <flash_map_backend/flash_map_backend.h>
+#include <hal/hal_bsp.h>
+#include <hal/hal_flash_int.h>
 
 int flash_area_id_from_multi_image_slot(int image_index, int slot)
 {
@@ -41,4 +43,37 @@ int flash_area_id_to_multi_image_slot(int image_index, int area_id)
         return 1;
     }
     return 255;
+}
+
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
+{
+    const struct flash_area *fa;
+    const struct hal_flash *hf;
+    uint32_t start;
+    uint32_t size;
+    int rc;
+    int i;
+
+    rc = flash_area_open(FLASH_AREA_IMAGE_0, &fa);
+    if (rc != 0) {
+        return -1;
+    }
+
+    rc = -1;
+    hf = hal_bsp_flash_dev(fa->fa_device_id);
+    for (i = 0; i < hf->hf_sector_cnt; i++) {
+        hf->hf_itf->hff_sector_info(hf, i, &start, &size);
+        if (start < fa->fa_off) {
+            continue;
+        }
+        if (off >= start - fa->fa_off && off <= (start - fa->fa_off) + size) {
+            sector->fs_off = start - fa->fa_off;
+            sector->fs_size = size;
+            rc = 0;
+            break;
+        }
+    }
+
+    flash_area_close(fa);
+    return rc;
 }

--- a/boot/zephyr/Kconfig.serial_recovery
+++ b/boot/zephyr/Kconfig.serial_recovery
@@ -51,6 +51,14 @@ config MCUBOOT_SERIAL_DIRECT_IMAGE_UPLOAD
 	  Note that 0 is default upload target when no explicit
 	  selection is done.
 
+config BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
+	int "Stack buffer for unaligned memory writes"
+	default 64
+	help
+	  Specifies the stack usage for a buffer which is used for unaligned
+	  memory access when data is written to a device with memory alignment
+	  requirements. Set to 0 to disable.
+
 config BOOT_MAX_LINE_INPUT_LEN
 	int "Maximum input line length"
 	default 512

--- a/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
+++ b/boot/zephyr/boards/nrf52840dk_qspi_nor_secondary.overlay
@@ -7,7 +7,6 @@
 /delete-node/ &boot_partition;
 /delete-node/ &slot0_partition;
 /delete-node/ &slot1_partition;
-/delete-node/ &scratch_partition;
 
 &flash0 {
 	partitions {

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -245,6 +245,10 @@
 #define MCUBOOT_SERIAL_MAX_RECEIVE_SIZE CONFIG_BOOT_SERIAL_MAX_RECEIVE_SIZE
 #endif
 
+#ifdef CONFIG_BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
+#define MCUBOOT_SERIAL_UNALIGNED_BUFFER_SIZE CONFIG_BOOT_SERIAL_UNALIGNED_BUFFER_SIZE
+#endif
+
 /* Support 32-byte aligned flash sizes */
 #if DT_HAS_CHOSEN(zephyr_flash)
     #if DT_PROP_OR(DT_CHOSEN(zephyr_flash), write_block_size, 0) > 8

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -190,7 +190,9 @@ static void do_boot(struct boot_rsp *rsp)
                                      rsp->br_hdr->ih_hdr_size);
 #endif
 
-    sys_clock_disable();
+    if (IS_ENABLED(CONFIG_SYSTEM_TIMER_HAS_DISABLE_SUPPORT)) {
+        sys_clock_disable();
+    }
 
 #ifdef CONFIG_USB_DEVICE_STACK
     /* Disable the USB to prevent it from firing interrupts */

--- a/ci/fih-tests_run.sh
+++ b/ci/fih-tests_run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ set -e
 pushd .. &&\
    git clone https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git &&\
    pushd trusted-firmware-m &&\
-   git checkout TF-Mv1.4.0 &&\
+   git checkout TF-Mv1.7.0 &&\
    popd
 
 if [[ $GITHUB_ACTIONS == true ]]; then

--- a/ci/fih_test_docker/execute_test.sh
+++ b/ci/fih_test_docker/execute_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ cmake -B $TFM_BUILD_DIR \
 cd $TFM_BUILD_DIR
 make -j install
 
-BOOTLOADER_AXF='./install/outputs/ARM/MPS2/AN521/bl2.axf'
+BOOTLOADER_AXF='./install/outputs/bl2.axf'
 
 $MCUBOOT_PATH/ci/fih_test_docker/run_fi_test.sh $BOOTLOADER_AXF $SKIP_SIZE $DAMAGE_TYPE> fih_test_output.yaml
 

--- a/ci/fih_test_docker/fi_tester_gdb.sh
+++ b/ci/fih_test_docker/fi_tester_gdb.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2020-2022 Arm Limited
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ function skip_instruction {
 
     cat >commands.gdb <<EOF
 target remote localhost: 1234
+file $IMAGE_DIR/bl2.axf
+b boot_go_for_image_id if image_id == 0
+continue
+delete breakpoints 1
 b *$SKIP_ADDRESS
 continue&
 eval "shell sleep 0.5"
@@ -138,7 +142,7 @@ usage() {
 
 #defaults
 SKIP=2
-BIN_DIR=$(pwd)/install/outputs/ARM/MPS2/AN521
+BIN_DIR=$(pwd)/install/outputs
 AXF_FILE=$BIN_DIR/bl2.axf
 GDB=gdb-multiarch
 BOOTLOADER=true

--- a/ci/mynewt_targets/swap_move/pkg.yml
+++ b/ci/mynewt_targets/swap_move/pkg.yml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pkg.name: "targets/swap_move"
+pkg.type: "target"
+pkg.description:
+pkg.author:
+pkg.homepage:
+
+pkg.deps:
+    - "@mcuboot/boot/mynewt"

--- a/ci/mynewt_targets/swap_move/syscfg.yml
+++ b/ci/mynewt_targets/swap_move/syscfg.yml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.vals:
+    BOOT_SERIAL: 0
+    BOOT_SERIAL_DETECT_PIN: 11
+    BOOT_SERIAL_DETECT_PIN_VAL: 0
+    BOOT_SERIAL_REPORT_PIN: 13
+    BOOTUTIL_VALIDATE_SLOT0: 0
+    BOOTUTIL_MAX_IMG_SECTORS: 256
+    BOOTUTIL_SWAP_USING_MOVE: 1
+    BOOTUTIL_SIGN_EC256: 0
+    BOOTUTIL_SIGN_RSA: 0
+    BOOTUTIL_ENCRYPT_RSA: 0
+    BOOTUTIL_ENCRYPT_KW: 0
+    BOOTUTIL_USE_MBED_TLS: 0
+    BOOTUTIL_USE_TINYCRYPT: 1
+    BOOTUTIL_OVERWRITE_ONLY: 0
+    BOOTUTIL_OVERWRITE_ONLY_FAST: 1
+    BOOTUTIL_HAVE_LOGGING: 0
+    BOOTUTIL_NO_LOGGING: 1
+    BOOTUTIL_LOG_LEVEL: 'BOOTUTIL_LOG_LEVEL_INFO'
+    CONSOLE_COMPAT: 1
+    CONSOLE_INPUT: 0
+    CONSOLE_UART: 0
+    CONSOLE_RTT: 0
+    OS_CPUTIME_TIMER_NUM: 0
+    TIMER_0: 1
+    UART_0: 0
+    BOOTUTIL_BOOTSTRAP: 0
+    MBEDTLS_NIST_KW_C: 0

--- a/ci/mynewt_targets/swap_move/target.yml
+++ b/ci/mynewt_targets/swap_move/target.yml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+target.app: "@mcuboot/boot/mynewt"
+target.bsp: "@apache-mynewt-core/hw/bsp/nordic_pca10056"
+target.build_profile: "optimized"

--- a/docs/design.md
+++ b/docs/design.md
@@ -226,13 +226,13 @@ allows hundreds to thousands of field upgrades in production is recommended.
 swap-using scratch algorithm assumes that the primary and the secondary image
 slot areas sizes are equal.
 The maximum image size available for the application
-will be:  
+will be:
 ```
 maximum-image-size = image-slot-size - image-trailer-size
 ```
 
-Where:  
-  `image-slot-size` is the size of the image slot.  
+Where:
+  `image-slot-size` is the size of the image slot.
   `image-trailer-size` is the size of the image trailer.
 
 ### [Swap without using scratch](#image-swap-no-scratch)
@@ -241,8 +241,8 @@ This algorithm is an alternative to the swap-using-scratch algorithm.
 It uses an additional sector in the primary slot to make swap possible.
 The algorithm works as follows:
 
-  1.	Moves all sectors of the primary slot up by one sector.  
-    Beginning from N=0:  
+  1.	Moves all sectors of the primary slot up by one sector.
+    Beginning from N=0:
   2.	Copies the N-th sector from the secondary slot to the N-th sector of the
   primary slot.
   3.	Copies the (N+1)-th sector from the primary slot to the N-th sector of the
@@ -257,13 +257,13 @@ The algorithm is limited to support sectors of the same
 sector layout. All slot's sectors should be of the same size.
 
 When using this algorithm the maximum image size available for the application
-will be:  
+will be:
 ```
 maximum-image-size = (N-1) * slot-sector-size - image-trailer-sectors-size
 ```
 
-Where:  
-  `N` is the number of sectors in the primary slot.  
+Where:
+  `N` is the number of sectors in the primary slot.
   `image-trailer-sectors-size` is the size of the image trailer rounded up to
   the total size of sectors its occupied. For instance if the image-trailer-size
   is equal to 1056 B and the sector size is equal to 1024 B, then
@@ -1468,8 +1468,8 @@ are issued from the MCUboot source directory):
 ```sh
 $ mkdir docker
 $ ./ci/fih-tests_install.sh
-$ FIH_LEVEL=MCUBOOT_FIH_PROFILE_MEDIUM BUILD_TYPE=RELEASE SKIP_SIZE=2 \
-    DAMAGE_TYPE=SIGNATURE ./ci/fih-tests_run.sh
+$ FIH_LEVEL=MEDIUM BUILD_TYPE=RELEASE SKIP_SIZE=2 DAMAGE_TYPE=SIGNATURE \
+     ./ci/fih-tests_run.sh
 ```
 On the travis CI the environment variables in the last command are set based on
 the configs provided in the `.travis.yaml`

--- a/docs/readme-espressif.md
+++ b/docs/readme-espressif.md
@@ -130,6 +130,28 @@ For signing with a crypto key and guarantee the authenticity of the image being 
 esptool.py -p <PORT> -b <BAUD> --before default_reset --after hard_reset --chip <TARGET>  write_flash --flash_mode dio --flash_size <FLASH_SIZE> --flash_freq 40m <SLOT_OFFSET> <SIGNED_BIN>
 ```
 
+# [Downgrade prevention](#downgrade-prevention)
+
+Downgrade prevention (avoid updating of images to an older version) can be enabled using the following configuration:
+
+```
+CONFIG_ESP_DOWNGRADE_PREVENTION=y
+```
+
+MCUboot will then verify and compare the new image version number with the current one before perform an update swap.
+
+Version number is added to the image when signing it with `imgtool` (`-v` parameter, e.g. `-v 1.0.0`).
+
+### [Downgrade prevention with security counter](#downgrade-prevention-with-security-counter)
+
+It is also possible to rely on a security counter, also added to the image when signing with `imgtool` (`-s` parameter), apart from version number. This allows image downgrade at some extent, since any update must have greater or equal security counter value. Enable using the following configuration:
+
+```
+CONFIG_ESP_DOWNGRADE_PREVENTION_SECURITY_COUNTER=y
+```
+
+E.g.: if the current image was signed using `-s 1` parameter, an eventual update image must have been signed using security counter `-s 1` or greater.
+
 # [Security Chain on Espressif port](#security-chain-on-espressif-port)
 
 [MCUboot encrypted images](encrypted_images.md) do not provide full code confidentiality when only external storage is available (see [Threat model](encrypted_images.md#threat-model)) since by MCUboot design the image in Primary Slot, from where the image is executed, is stored plaintext.

--- a/ext/nrf/cc310_glue.c
+++ b/ext/nrf/cc310_glue.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
 #include "cc310_glue.h"

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 #ifndef NRF_CC310_GLUE_H__
 #define NRF_CC310_GLUE_H__

--- a/scripts/imgtool/keys/ed25519.py
+++ b/scripts/imgtool/keys/ed25519.py
@@ -34,7 +34,7 @@ class Ed25519Public(KeyClass):
                 encoding=serialization.Encoding.DER,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo)
 
-    def get_private_bytes(self, minimal):
+    def get_private_bytes(self, minimal, format):
         self._unsupported('get_private_bytes')
 
     def export_private(self, path, passwd=None):
@@ -75,7 +75,7 @@ class Ed25519(Ed25519Public):
     def _get_public(self):
         return self.key.public_key()
 
-    def get_private_bytes(self, minimal):
+    def get_private_bytes(self, minimal, format):
         raise Ed25519UsageError("Operation not supported with {} keys".format(
             self.shortname()))
 

--- a/scripts/imgtool/keys/privatebytes.py
+++ b/scripts/imgtool/keys/privatebytes.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from cryptography.hazmat.primitives import serialization
+
+
+class PrivateBytesMixin():
+    def _get_private_bytes(self, minimal, format, exclass):
+        if format is None:
+            format = self._DEFAULT_FORMAT
+        if format not in self._VALID_FORMATS:
+            raise exclass("{} does not support {}".format(
+                self.shortname(), format))
+        return format, self.key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=self._VALID_FORMATS[format],
+                encryption_algorithm=serialization.NoEncryption())

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -157,8 +157,8 @@ def getpub(key, encoding, lang):
 @click.option('-k', '--key', metavar='filename', required=True)
 @click.option('-f', '--format',
               type=click.Choice(valid_formats),
-              help='Valid formats: {}'.format(', '.join(valid_formats)),
-              default='pkcs8')
+              help='Valid formats: {}'.format(', '.join(valid_formats))
+              )
 @click.command(help='Dump private key from keypair')
 def getpriv(key, minimal, format):
     key = load_key(key)


### PR DESCRIPTION
Synchronized to:
https://github.com/mcu-tools/mcuboot/commit/90b8f69040e604254daa7ffe58dd9add985b468a

Changes included:
boot: zephyr: Only call sys_clock_disable when supported
imgtool: fix getpriv format type for keys
mynewt: add flash sector requirement for swap move
ci: add Mynewt test target for swap move
ci: Fix compatibility with packaging==22
boot_serial: Add unaligned stack buffer writing
doc: espressif: Add warning note for Flash Encryption with Serial Recovery usage

Note: The following commits exists in both branches
boot: zephyr: boards: nrf52840dk: Fix overlay
espressif: add downgrade prevention feature
boot: Update Nordic's license identifier tag
docs: fix FIH example command in design.md
ci: fih: update TF-M version to 1.7.0 and adjust test suite

merged using GitHub web gui.