### PR TITLE
boot/zephyr: switch main return type to 'int'

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -495,7 +495,7 @@ static void boot_serial_enter()
 }
 #endif
 
-void main(void)
+int main(void)
 {
     struct boot_rsp rsp;
     int rc;


### PR DESCRIPTION
Adapt to Zephyr's change requiring main to return int.