### PR TITLE
boot: boot_serial: fix usage of zcbor_new_encode_state API

### DIFF
--- a/boot/boot_serial/src/boot_serial.c
+++ b/boot/boot_serial/src/boot_serial.c
@@ -133,7 +133,7 @@ static zcbor_state_t cbor_state[2];
 void reset_cbor_state(void)
 {
     zcbor_new_encode_state(cbor_state, 2, (uint8_t *)bs_obuf,
-        (size_t)bs_obuf + sizeof(bs_obuf), 0);
+        sizeof(bs_obuf), 0);
 }
 
 /**


### PR DESCRIPTION
Fix usage of zcbor_new_encode_state API, to correctly pass the payload length. The previous usage was passing a pointer to the end of the payload, which resulted in the ZCBOR structure being initialized with an invalid `payload_end` field. On some platforms, this breaks MCUBoot serial recovery, as the ZCBOR structures required to send response data are invalid and can no longer be populated with response data.