### PR TITLE
zephyr: remove the aarch32 directory from the header

### DIFF
--- a/boot/zephyr/arm_cleanup.c
+++ b/boot/zephyr/arm_cleanup.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/cortex_m/cmsis.h>
 #include <zephyr/toolchain.h>
 
 #if CONFIG_CPU_HAS_NXP_MPU

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -28,9 +28,9 @@
 #include <zephyr/linker/linker-defs.h>
 
 #if defined(CONFIG_CPU_AARCH32_CORTEX_A) || defined(CONFIG_CPU_AARCH32_CORTEX_R)
-#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/arch/arm/cortex_a_r/cmsis.h>
 #elif defined(CONFIG_CPU_CORTEX_M)
-#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/cortex_m/cmsis.h>
 #endif
 
 #include "target.h"


### PR DESCRIPTION
The aarch32 directory is going to be deleted in Zephyr's main tree and the change needs to be synchronoused here.

Related PR: https://github.com/zephyrproject-rtos/zephyr/pull/60031