### PR TITLE
boot: zephyr: fix duplicate symbols with tinycrypt

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -168,8 +168,10 @@ if(CONFIG_BOOT_SIGNATURE_TYPE_ECDSA_P256 OR CONFIG_BOOT_ENCRYPT_EC256)
     ${TINYCRYPT_DIR}/source/ecc.c
     ${TINYCRYPT_DIR}/source/ecc_dsa.c
     ${TINYCRYPT_DIR}/source/sha256.c
-    ${TINYCRYPT_DIR}/source/utils.c
     )
+    if(NOT CONFIG_ZEPHYR_TINYCRYPT_MODULE)
+      zephyr_library_sources(${TINYCRYPT_DIR}/source/utils.c)
+    endif()
   elseif(CONFIG_BOOT_USE_NRF_CC310_BL)
     zephyr_library_sources(${NRF_DIR}/cc310_glue.c)
     zephyr_library_include_directories(${NRF_DIR})


### PR DESCRIPTION
When building Zephyr with mcuboot, with tinycrypt instead of mbedtls, there are duplicate symbols between the tinycrypt module and the in-tree copy of tinycrypt that is included with mcuboot.

```shell
/opt/zephyr/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(utils.c.obj): in function `_copy':
/Users/cfriedt/zephyrproject/modules/crypto/tinycrypt/lib/source/utils.c:42: multiple definition of `_copy'; app/libapp.a(utils.c.obj):/Users/cfriedt/zephyrproject/bootloader/mcuboot/ext/tinycrypt/lib/source/utils.c:42: first defined here
/opt/zephyr/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(utils.c.obj): in function `_set':
/Users/cfriedt/zephyrproject/modules/crypto/tinycrypt/lib/source/utils.c:52: multiple definition of `_set'; app/libapp.a(utils.c.obj):/Users/cfriedt/zephyrproject/bootloader/mcuboot/ext/tinycrypt/lib/source/utils.c:52: first defined here
/opt/zephyr/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(utils.c.obj): in function `_double_byte':
/Users/cfriedt/zephyrproject/modules/crypto/tinycrypt/lib/source/utils.c:61: multiple definition of `_double_byte'; app/libapp.a(utils.c.obj):/Users/cfriedt/zephyrproject/bootloader/mcuboot/ext/tinycrypt/lib/source/utils.c:61: first defined here
/opt/zephyr/zephyr-sdk-0.16.8/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.2.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(utils.c.obj): in function `_compare':
/Users/cfriedt/zephyrproject/modules/crypto/tinycrypt/lib/source/utils.c:70: multiple definition of `_compare'; app/libapp.a(utils.c.obj):/Users/cfriedt/zephyrproject/bootloader/mcuboot/ext/tinycrypt/lib/source/utils.c:70: first defined here
```

The issues are only with symbols in the file

```shell
${TINYCRYPT_DIR}/source/utils.c
```

If Zephyr is being built with the tinycrypt module present, prefer that over the in-tree copy.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/76276