### PR TITLE
boot: zephyr: boards: Assign boot_partition to code-patition

### DIFF
--- a/boot/zephyr/boards/rpi_pico_rp2040_mcuboot.overlay
+++ b/boot/zephyr/boards/rpi_pico_rp2040_mcuboot.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* /delete-node/ &code_partition; */
+
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};

--- a/boot/zephyr/boards/rpi_pico_rp2040_w_mcuboot.overlay
+++ b/boot/zephyr/boards/rpi_pico_rp2040_w_mcuboot.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025 Beechwoods Software Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <raspberrypi/partitions_2M_sysbuild.dtsi>
+
+/ {
+	chosen {
+		zephyr,code-partition = &boot_partition;
+	};
+};


### PR DESCRIPTION
Include the 2M SysBuild partitions using board variants:
 - rpi_pico/rp2040/mcuboot
 - rpi_pico/rp2040/w/mcuboot