### PR TITLE
boot: zephyr: adjust sample.yaml to pass USB deprecation process

### DIFF
--- a/boot/zephyr/sample.yaml
+++ b/boot/zephyr/sample.yaml
@@ -49,19 +49,20 @@ tests:
     tags: bootloader_mcuboot
   sample.bootloader.mcuboot.usb_cdc_acm_recovery:
     tags: bootloader_mcuboot
-    platform_allow:  nrf52840dongle/nrf52840
+    platform_allow: nrf52840dongle/nrf52840
     extra_args:
       - EXTRA_CONF_FILE=./usb_cdc_acm_recovery.conf
       - DTC_OVERLAY_FILE="./usb_cdc_acm.overlay;app.overlay"
-    integration_platforms:
-      - nrf52840dongle/nrf52840
+    extra_configs:
+      - CONFIG_DEPRECATION_TEST=y
   sample.bootloader.mcuboot.usb_cdc_acm_recovery_log:
-    extra_args: EXTRA_CONF_FILE=./usb_cdc_acm_log_recovery.conf
-      DTC_OVERLAY_FILE="./boards/nrf52840_big.overlay;app.overlay"
-    platform_allow:  nrf52840dk/nrf52840
-    integration_platforms:
-      - nrf52840dk/nrf52840
     tags: bootloader_mcuboot
+    platform_allow: nrf52840dk/nrf52840
+    extra_args:
+      - EXTRA_CONF_FILE=./usb_cdc_acm_log_recovery.conf
+      - DTC_OVERLAY_FILE="./boards/nrf52840_big.overlay;app.overlay"
+    extra_configs:
+      - CONFIG_DEPRECATION_TEST=y
   sample.bootloader.mcuboot.single_slot:
     extra_args: EXTRA_CONF_FILE=./single_slot.conf
       DTC_OVERLAY_FILE="./boards/nrf52840_single_slot.overlay;app.overlay"


### PR DESCRIPTION
The new stack comes with a higher demand for flash. We need to adapt the overlay file for the platform used for testing. The legacy stack is in the process of being deprecated. The NRF52840 dongle should not enable the legacy stack by default. The Zephyr's new stack provides helper code to use CDC ACM as the serial backend. The only required change to the serial adapter code is to get the USB device instance and enable it.