### PR TITLE
zephyr: remove commented configs for tinycrypt

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -11,12 +11,6 @@ CONFIG_BOOT_BOOTSTRAP=n
 ### mbedTLS has its own heap
 # CONFIG_HEAP_MEM_POOL_SIZE is not set
 
-### We never want Zephyr's copy of tinycrypt.  If tinycrypt is needed,
-### MCUboot has its own copy in tree.
-# CONFIG_TINYCRYPT is not set
-# CONFIG_TINYCRYPT_ECC_DSA is not set
-# CONFIG_TINYCRYPT_SHA256 is not set
-
 CONFIG_FLASH=y
 
 ### Various Zephyr boards enable features that we don't want.


### PR DESCRIPTION
Those commented configs cause build issues when tinycrypt is not
available.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
