### PR TITLE
boot: zephyr: Remove reference to deprecated BT_CTLR option

### DIFF
--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -15,7 +15,6 @@ CONFIG_FLASH=y
 
 ### Various Zephyr boards enable features that we don't want.
 # CONFIG_BT is not set
-# CONFIG_BT_CTLR is not set
 # CONFIG_I2C is not set
 
 CONFIG_LOG=y


### PR DESCRIPTION
This Kconfig option has been deprecated. It has been replaced by HAS_BT_CTLR, however that's a promptless option so it can't be explicitly disabled.