### PR TITLE
sync on pending P-R "boot: zephyr: use DT_REG_*() macros"

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -94,13 +94,14 @@ const struct boot_uart_funcs boot_funcs = {
 #include <arm_cleanup.h>
 #endif
 
-#if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
-    !defined(CONFIG_LOG_MODE_MINIMAL)
+#if defined(CONFIG_LOG)
+#include <zephyr/logging/log_ctrl.h>
+
+#if !defined(CONFIG_LOG_MODE_IMMEDIATE) && !defined(CONFIG_LOG_MODE_MINIMAL)
 #ifdef CONFIG_LOG_PROCESS_THREAD
 #warning "The log internal thread for log processing can't transfer the log"\
          "well for MCUBoot."
 #else
-#include <zephyr/logging/log_ctrl.h>
 
 #define BOOT_LOG_PROCESSING_INTERVAL K_MSEC(30) /* [ms] */
 
@@ -114,13 +115,13 @@ K_SEM_DEFINE(boot_log_sem, 0, 1);
 #define ZEPHYR_BOOT_LOG_START() zephyr_boot_log_start()
 #define ZEPHYR_BOOT_LOG_STOP() zephyr_boot_log_stop()
 #endif /* CONFIG_LOG_PROCESS_THREAD */
-#else
-/* synchronous log mode doesn't need to be initalized by the application */
+#endif /* !IMMEDIATE && !MINIMAL */
+#endif /* CONFIG_LOG */
+
+#if !defined(ZEPHYR_BOOT_LOG_START)
 #define ZEPHYR_BOOT_LOG_START() ((void)0)
 #define ZEPHYR_BOOT_LOG_STOP() ((void)0)
-#endif /* defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
-        * !defined(CONFIG_LOG_MODE_MINIMAL)
-	*/
+#endif
 
 BOOT_LOG_MODULE_REGISTER(mcuboot);
 
@@ -478,6 +479,9 @@ void zephyr_boot_log_stop(void)
      * see https://github.com/zephyrproject-rtos/zephyr/issues/21500
      */
     (void)k_sem_take(&boot_log_sem, K_FOREVER);
+
+    /* Entice the log backends to flush their contents */
+    LOG_PANIC();
 }
 #endif /* defined(CONFIG_LOG) && !defined(CONFIG_LOG_MODE_IMMEDIATE) && \
         * !defined(CONFIG_LOG_PROCESS_THREAD) && !defined(CONFIG_LOG_MODE_MINIMAL)

--- a/boot/zephyr/ram_load.c
+++ b/boot/zephyr/ram_load.c
@@ -24,8 +24,8 @@ int boot_get_image_exec_ram_info(uint32_t image_id,
                                  uint32_t *exec_ram_size)
 {
 #ifdef CONFIG_SOC_SERIES_STM32N6X
-    *exec_ram_start = DT_PROP_BY_IDX(DT_NODELABEL(axisram1), reg, 0);
-    *exec_ram_size = DT_PROP_BY_IDX(DT_NODELABEL(axisram1), reg, 1);
+    *exec_ram_start = DT_REG_ADDR(DT_NODELABEL(axisram1));
+    *exec_ram_size = DT_REG_SIZE(DT_NODELABEL(axisram1));
 #endif
 
     return 0;


### PR DESCRIPTION
Sync on MCUboot P-R https://github.com/mcu-tools/mcuboot/pull/2655 for the below commit that is required by https://github.com/zephyrproject-rtos/zephyr/pull/104765.

> boot: zephyr: use DT_REG_*() macros
>
> Use DT_REG_ADDR() and DT_REG_SIZE() macros to get the target load
> area address range. This is more flexible is case the node rely on
> some DT ranges property.

This P-R also brings a MCUboot commit Zephyr will likely syn on soon:
> boot: zephyr: call LOG_PANIC before jumping to app to flush in flight logs
>
> Call LOG_PANIC() after ZEPHYR_BOOT_LOG_STOP() to give every log
> backend the opportunity to finish transmitting before jumping to
> the app.