### PR TITLE
bootutil: Use mbedtls/private paths for TF-PSA-Crypto

### DIFF
--- a/boot/bootutil/include/bootutil/crypto/common.h
+++ b/boot/bootutil/include/bootutil/crypto/common.h
@@ -7,6 +7,24 @@
 #ifndef __BOOTUTIL_CRYPTO_COMMON_H__
 #define __BOOTUTIL_CRYPTO_COMMON_H__
 
+/*
+ * TF-PSA-Crypto keeps several legacy crypto declarations under the
+ * mbedtls private include tree (e.g. mbedtls/private/sha256.h).
+ * Classic Mbed TLS exposes the same APIs under mbedtls/sha256.h.
+ * Unless the build forces MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR to 0 or 1,
+ * detect at preprocess time whether the private sha256 header exists.
+ */
+#if defined(MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR)
+#elif defined(__has_include)
+#if __has_include(<mbedtls/private/sha256.h>)
+#define MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR 1
+#else
+#define MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR 0
+#endif
+#else
+#define MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR 0
+#endif
+
 /* The check below can be performed even for those cases
  * where MCUBOOT_USE_MBED_TLS has not been defined
  */

--- a/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdh_p256.h
@@ -19,8 +19,13 @@
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/ecp.h>
-    #include <mbedtls/ecdh.h>
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecp.h>
+#else
+#include <mbedtls/ecp.h>
+#endif
+#include <mbedtls/ecdh.h>
     #define EC256_PUBK_LEN (65)
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/boot/bootutil/include/bootutil/crypto/ecdsa.h
+++ b/boot/bootutil/include/bootutil/crypto/ecdsa.h
@@ -58,10 +58,15 @@
     #include <psa/crypto.h>
     #include <string.h>
 #elif defined(MCUBOOT_USE_MBED_TLS)
-    #include <mbedtls/ecdsa.h>
-    /* Indicate to the caller that the verify function needs the raw ASN.1
-     * signature, not a decoded one. */
-    #define MCUBOOT_ECDSA_NEED_ASN1_SIG
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/ecdsa.h>
+#else
+#include <mbedtls/ecdsa.h>
+#endif
+/* Indicate to the caller that the verify function needs the raw ASN.1
+ * signature, not a decoded one. */
+#define MCUBOOT_ECDSA_NEED_ASN1_SIG
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 /*TODO: remove this after cypress port mbedtls to abstract crypto api */

--- a/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
+++ b/boot/bootutil/include/bootutil/crypto/hmac_sha256.h
@@ -19,10 +19,15 @@
 #endif
 
 #if defined(MCUBOOT_USE_MBED_TLS)
-    #include <stdint.h>
-    #include <stddef.h>
-    #include <mbedtls/cmac.h>
-    #include <mbedtls/md.h>
+#include <stdint.h>
+#include <stddef.h>
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/cmac.h>
+#else
+#include <mbedtls/cmac.h>
+#endif
+#include <mbedtls/md.h>
 #endif /* MCUBOOT_USE_MBED_TLS */
 
 #if defined(MCUBOOT_USE_TINYCRYPT)

--- a/boot/bootutil/include/bootutil/crypto/rsa.h
+++ b/boot/bootutil/include/bootutil/crypto/rsa.h
@@ -43,8 +43,12 @@
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
-#include "mbedtls/rsa.h"
-#include "mbedtls/version.h"
+#include "bootutil/crypto/common.h"
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include "mbedtls/private/rsa.h"
+#else
+#include <mbedtls/rsa.h>
+#endif
 #if defined(BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED)
 #if MBEDTLS_VERSION_NUMBER >= 0x03000000
 #include "rsa_alt_helpers.h"
@@ -53,7 +57,6 @@
 #endif
 #endif /* BOOTUTIL_CRYPTO_RSA_CRYPT_ENABLED */
 #include "mbedtls/asn1.h"
-#include "bootutil/crypto/common.h"
 
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/boot/bootutil/include/bootutil/crypto/sha.h
+++ b/boot/bootutil/include/bootutil/crypto/sha.h
@@ -62,10 +62,20 @@
 
 #elif defined(MCUBOOT_USE_MBED_TLS)
 
+#include "bootutil/crypto/common.h"
+
 #ifdef MCUBOOT_SHA512
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/sha512.h>
+#else
 #include <mbedtls/sha512.h>
+#endif
+#else
+#if MCUBOOT_MBEDTLS_CRYPTO_IN_PRIVATE_SUBDIR
+#include <mbedtls/private/sha256.h>
 #else
 #include <mbedtls/sha256.h>
+#endif
 #endif
 
 #include <mbedtls/version.h>

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdh_p256.h
@@ -16,9 +16,9 @@
 #include <stddef.h>
 
 #include <mbedtls/build_info.h>
-#include <mbedtls/ecp.h>
+#include <mbedtls/private/ecp.h>
 #include <mbedtls/ecdh.h>
-#include <mbedtls/bignum.h>
+#include <mbedtls/private/bignum.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_ecdsa.h
@@ -18,7 +18,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <mbedtls/ecdsa.h>
+#include <mbedtls/private/ecdsa.h>
 #include <mbedtls/asn1.h>
 #include <mbedtls/oid.h>
 

--- a/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
+++ b/sim/mcuboot-sys/csupport/custom_crypto/sim_custom_sha.h
@@ -12,7 +12,7 @@
 #define SIM_CUSTOM_SHA_H
 
 #include <stdint.h>
-#include <mbedtls/sha256.h>
+#include <mbedtls/private/sha256.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/sim/mcuboot-sys/csupport/run.c
+++ b/sim/mcuboot-sys/csupport/run.c
@@ -15,7 +15,7 @@
 #include "bootsim.h"
 
 #ifdef MCUBOOT_ENCRYPT_RSA
-#include "mbedtls/rsa.h"
+#include "mbedtls/private/rsa.h"
 #include "mbedtls/asn1.h"
 #endif
 


### PR DESCRIPTION
MCUboot Mbed TLS crypto wrappers and simulator custom crypto helpers included legacy headers as mbedtls/<alg>.h. TF-PSA-Crypto now exposes these declarations only under mbedtls/private/.

Assisted-by: Cursor: Auto